### PR TITLE
Exposing 'Fase Codice' filter on Piano filterset

### DIFF
--- a/strt/serapide_core/api/schema.py
+++ b/strt/serapide_core/api/schema.py
@@ -102,9 +102,6 @@ class PianoNode(DjangoObjectType):
             'ente': ['exact'],
             'descrizione': ['exact', 'icontains'],
             'tipologia': ['exact', 'icontains'],
-            'fase': ['exact'],
-            'fase__nome': ['exact'],
-            'fase__codice': ['exact'],
         }
         interfaces = (relay.Node, )
 
@@ -331,6 +328,7 @@ class EnteUserMembershipFilter(django_filters.FilterSet):
 class PianoUserMembershipFilter(django_filters.FilterSet):
     # Do case-insensitive lookups on 'name'
     codice = django_filters.CharFilter(lookup_expr='iexact')
+    fase__codice = django_filters.CharFilter(lookup_expr='iexact')
 
     class Meta:
         model = Piano


### PR DESCRIPTION
"Fase" is a relationship on "Piano" object managed by Django ORM.

By default, Graphene schema handles those only by the foreign key.

As a frontend developer, I would need to be able to filter out "Piano" objects through their "Fase" code also, something like:

```
query {
  piani (fase_Codice: "FP0034") {
    edges {
      node {
        fase {
          nome,
          codice
        }
      }
    }
  }
}
```


