### PR TITLE
SideBar pagina piano

### DIFF
--- a/strt/serapide_client/public/index.html
+++ b/strt/serapide_client/public/index.html
@@ -15,8 +15,8 @@
 
 {% block content %}
 
-        <div id="serapide" class="serapide">
-        </div>
+
+    <div id="serapide" class="serapide"></div>
 
 {% endblock content %}
 

--- a/strt/serapide_client/src/App.js
+++ b/strt/serapide_client/src/App.js
@@ -12,7 +12,7 @@ import client from "./apolloclient"
 import Home from './pages/Home'
 import NuovoPiano from './pages/NuovoPiano'
 import CreaAnagrafica from './pages/CreaAnagrafica'
-import Anagrafica from './pages/Anagrafica'
+import Piano from './pages/Piano'
 import Injector from './components/Injector'
 import NavBar from './components/NavigationBar'
 import {messaggi} from './resources'
@@ -28,8 +28,8 @@ export default () => {
          <ToastContainer/>
             <Router>
               <Switch>
+                <Route  path="/piano/:code" component={Piano}/>
                 <Route  path="/crea_anagrafica/:code" component={CreaAnagrafica}/>
-                <Route  path="/anagrafica/:code" component={Anagrafica}/>
                 <Route  path="/nuovo_piano/" component={NuovoPiano}/>             
                 <Route  path="/" component={Home}/>
               </Switch>

--- a/strt/serapide_client/src/components/EnhancedFileLoader.js
+++ b/strt/serapide_client/src/components/EnhancedFileLoader.js
@@ -12,7 +12,6 @@ import FileLoader from "./FileLoader"
 
 
 const showError = (error) => {
-    console.log(error);
     if (error && error.message.indexOf("Operation canceled") === -1) {
         toast.error(error.message,  {autoClose: true})
     }

--- a/strt/serapide_client/src/components/FileChooser.js
+++ b/strt/serapide_client/src/components/FileChooser.js
@@ -79,7 +79,6 @@ class FileChooser extends React.Component {
       if(modal && !open && showBtn) {
         return (<Button disabled={isLocked} color="warning" onClick={this.toggleOpen}>Upload</Button>)
       }
-      console.log(this.props.isLocked)
       const comp = this.renderChooser()
      return modal ? (
       <Modal toggle={this.toggleOpen} isOpen={open} centered size={`${sz === 'lg' ? 'md' : 'sm'}`} wrapClassName="serapide" autoFocus={true}>

--- a/strt/serapide_client/src/components/MenuItem.js
+++ b/strt/serapide_client/src/components/MenuItem.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react'
+import classNames from 'classnames'
+
+export default ({title, subtitle, icon, iconColor, active = false, locked = false, expanded = false, children, href}) => (
+    <li onClick={() => window.location.href= href} className={classNames("list-group-item", {active, locked, collapsed: !expanded})}>
+        <div className="d-flex align-items-center icons">
+            {locked && expanded  && (<i className="material-icons icon-12">lock</i>)}
+            <i className={classNames("material-icons", {"icon-16": !expanded}, iconColor)}>{icon}</i>
+        </div>
+        {expanded && (
+        <div className="d-flex flex-column">
+            <span className="title">{title}</span>
+            <span className="sub-title">{subtitle}</span>
+        </div>)}
+        {expanded && children}
+    </li>
+)

--- a/strt/serapide_client/src/components/SideBarMenu.js
+++ b/strt/serapide_client/src/components/SideBarMenu.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react'
+import MenuItem from './MenuItem'
+import {Badge} from 'reactstrap'
+import {toggleControllableState} from '../enhancers/utils'
+const enhancer = toggleControllableState("expanded", "toggleOpen", true)
+
+export default enhancer(({piano = {}, expanded, url, active, toggleOpen}) => (
+    <React.Fragment>
+        {expanded ? (
+            <div className="sidebar-header">
+            <span className="close" onClick={toggleOpen}>x</span>
+                <div className="d-flex flex-column pt-2">
+                    <div className="">PORTALE DEL TERRITORIO</div>
+                    <div className="piano-title text-capitalize">{`${piano.codice}`}</div>
+                </div>
+            </div>) : (
+            <div className="sidebar-header collapsed" onClick={toggleOpen}><i className="material-icons icon-16">reorder</i></div>)}
+        
+            <ul className="list-group">
+                <MenuItem href={`#${url}`} active={active === ""} title="HOME PIANO" icon="home" expanded={expanded}/>
+                <MenuItem href={`#${url}/anagrafica`} active={active === "/anagrafica"} title="ANAGRAFICA" icon="assignment" expanded={expanded}/>
+                <MenuItem href={`#${url}/avvio`} active={active === "/avvio"} title="AVVIO" subtitle="Avvio del Procedimento" icon="dashboard" expanded={expanded}/>
+                <MenuItem href={`#${url}/formazione`} active={active === "/formazione"} title="FORMAZIONE PIANO" subtitle="Accesso agli strumenti" icon="build" expanded={expanded}/>
+                <MenuItem href={`#${url}/adozione`} active={active === "/adozione"} title="ADOZIONE" icon="assignment" expanded={expanded}/>
+                <MenuItem href={`#${url}/approvazione`} active={active === "/approvazione"} title="APPROVAZIONE" icon="check_circle" expanded={expanded}/>
+                <MenuItem href={`#${url}/pubblicazione`} active={active === "/pubblicazione"} title="PUBBLICAZIONE" icon="assignment" expanded={expanded}/>
+                <MenuItem href={`#${url}/notifiche`} active={active === "/notifiche"} title="NOTIFICHE" icon="email" expanded={expanded}>
+                    <Badge color="light">1</Badge>
+                </MenuItem>
+                <MenuItem href={`#${url}/avvisi`} active={active === "/avvisi"} title="ALERT" icon="notification_important" iconColor="text-danger" expanded={expanded}>
+                    <Badge color="light">2</Badge>
+                </MenuItem>
+                
+            </ul>
+    </React.Fragment>
+))

--- a/strt/serapide_client/src/components/TabellaPiani.js
+++ b/strt/serapide_client/src/components/TabellaPiani.js
@@ -13,8 +13,11 @@ const goToAnagrafica = (codice, {nome} = {}) => {
     if(nome === "DRAFT"){
          window.location.href=`#/crea_anagrafica/${codice}`
         }else {
-            window.location.href=`#/anagrafica/${codice}`
+            window.location.href=`#/piano/${codice}/anagrafica`
         }
+}
+const goToPiano = (codice) => {
+        window.location.href=`#/piano/${codice}`
 }
 export default ({title, piani = []}) => (
     <Fragment>
@@ -46,7 +49,7 @@ export default ({title, piani = []}) => (
                             <StatoProgress stato={fase}></StatoProgress>
                         </td>
                         <td className="text-justify text-center">{user && `${user.firstName} ${user.lastName}`}</td>
-                        <td className="text-center"><i className="material-icons text-warning">play_circle_filled</i></td>
+                        <td className="text-center" style={{cursor: "pointer"}} onClick={() => goToPiano(codice)}><i className="material-icons text-warning">play_circle_filled</i></td>
                     </tr>))}
                 </tbody>
             </Table>

--- a/strt/serapide_client/src/components/VAS.js
+++ b/strt/serapide_client/src/components/VAS.js
@@ -30,11 +30,10 @@ const getAuthorities = ({contatti: {edges = []} = {}} = {}) => {
     return edges.map(({node: {nome, uuid}}) => ({label: nome, value: uuid}))
 }
 
-const showError = (error, onError) => {
+const showError = (error) => {
     toast.error(error.message,  {autoClose: true})
 }
 const checkAnagrafica =  (tipologia = "" , sP, auths, scas, semplificata, verifica) => {
-    console.log(tipologia, sP, auths, scas, semplificata, verifica)
     switch (tipologia.toLowerCase()) {
         case "semplificata":
         return semplificata && auths.length > 0 && !!sP
@@ -51,7 +50,7 @@ const checkAnagrafica =  (tipologia = "" , sP, auths, scas, semplificata, verifi
 
 export default ({codice, canUpdate, isLocked}) => {
     return (
-        <Query query={GET_VAS} variables={{codice}}>
+        <Query query={GET_VAS} variables={{codice}} onError={showError}>
             {({loading, data: {procedureVas: {edges = []} = []} = {}}) => {
                 if(loading){
                     return (
@@ -64,7 +63,7 @@ export default ({codice, canUpdate, isLocked}) => {
                     </div>)
             }
             
-            const {node: {uuid, tipologia, piano: {soggettoProponente: sP, codice, autoritaCompetenteVas: {edges: aut =[]} = {}, soggettiSca: {edges: sca =[]} = {}} = {}, risorse : {edges: resources = []} = {}} = {}} = edges[0] || {}
+            const {node: {uuid, tipologia, piano: {soggettoProponente: sP, autoritaCompetenteVas: {edges: aut =[]} = {}, soggettiSca: {edges: sca =[]} = {}} = {}, risorse : {edges: resources = []} = {}} = {}} = edges[0] || {}
             const {node: semplificata}= resources.filter(({node: n}) => n.tipo === "vas_semplificata").pop() || {};
             const {node: verifica} = resources.filter(({node: n}) => n.tipo === "vas_verifica").pop() || {};
             const disableSCA = tipologia === "SEMPLIFICATA" || tipologia === "NON_NECESSARIA"

--- a/strt/serapide_client/src/pages/Anagrafica.js
+++ b/strt/serapide_client/src/pages/Anagrafica.js
@@ -28,10 +28,10 @@ const getDataDeliberaInput = (codice) => (val) => ({
         codice}
     }})
 
-const canCommit = (dataDelibera, delibera, descrizione = "") =>  dataDelibera && delibera && descrizione.length > 0
+const canCommit = (dataDelibera, delibera, descrizione = "") =>  dataDelibera && delibera && descrizione && descrizione.length > 0
 
 
-export default ({match: {params: {code} = {}} = {}, selectDataDelibera, dataDelibera, ...props}) => {
+export default ({match: {params: {code} = {}} = {}, ...props}) => {
     return (<Query query={GET_PIANI} variables={{codice: code}}>
         {({loading, data: {piani: {edges = []} = []} = {}, error}) => {
             if(loading){
@@ -51,13 +51,13 @@ export default ({match: {params: {code} = {}} = {}, selectDataDelibera, dataDeli
             const locked = faseNome !== "DRAFT"
             const {node: delibera} = resources.filter(({node: n}) => n.tipo === "delibera").pop() || {};
             const optionals = resources.filter(({node: n}) => n.tipo === "delibera_opts").map(({node}) => (node) ) || {};
-            
+            if(!locked) {
+                window.location.href=`#/crea_anagrafica/${code}`
+            }
             return(
-            <div className="serapide-content pt-5 pb-5 pX-md px-1 serapide-top-offset position-relative overflow-x-scroll">
-                    <div className="d-flex flex-column ">
                         <div className="pb-4 pt-3 d-flex flex-row">
                             <i className="material-icons text-warning icon-34">assignment</i>
-                            <i className="material-icons text-warning">locked</i>
+                            <i style={{maxWidth: 26}} className="material-icons text-warning">locked</i>
                             <div className="d-flex flex-column flex-fill">
                                 <h3 className="mb-0">ANAGRAFICA</h3>
                                 <span className="pt-5">{getEnteLabelID(ente)}</span>
@@ -74,9 +74,8 @@ export default ({match: {params: {code} = {}} = {}, selectDataDelibera, dataDeli
                             </div>
                             
                         </div>
-                    </div>
                    
-            </div>)}
+            )}
         }
     </Query>)
     }

--- a/strt/serapide_client/src/pages/CreaAnagrafica.js
+++ b/strt/serapide_client/src/pages/CreaAnagrafica.js
@@ -38,7 +38,7 @@ const getDataDeliberaInput = (codice) => (val) => ({
         codice}
     }})
 
-const canCommit = (dataDelibera, delibera, descrizione = "") =>  dataDelibera && delibera && descrizione.length > 0
+const canCommit = (dataDelibera, delibera, descrizione = "") =>  dataDelibera && delibera && descrizione && descrizione.length > 0
 
 
 export default ({match: {params: {code} = {}} = {}, selectDataDelibera, dataDelibera, ...props}) => {
@@ -61,7 +61,9 @@ export default ({match: {params: {code} = {}} = {}, selectDataDelibera, dataDeli
             const locked = faseNome !== "DRAFT"
             const {node: delibera} = resources.filter(({node: n}) => n.tipo === "delibera").pop() || {};
             const optionals = resources.filter(({node: n}) => n.tipo === "delibera_opts").map(({node}) => (node) ) || {};
-            
+            if(locked) {
+                window.location.href=`#/pino/${code}/anagrafica`
+            }
             return(
             <div className="serapide-content pt-5 pb-5 pX-md px-1 serapide-top-offset position-relative overflow-x-scroll">
                     <div className="d-flex flex-column ">

--- a/strt/serapide_client/src/pages/NuovoPiano.js
+++ b/strt/serapide_client/src/pages/NuovoPiano.js
@@ -54,7 +54,7 @@ const updateCache = (cache, { data: {createPiano : {nuovoPiano: node}}  = {}} = 
                 data: { piani}
             })
         } catch (e) {
-            console.log("Query piani non inizializzata")
+            console.warn("Query piani non inizializzata")
         }
   }
 const Page = enhancer( ({creaPiano, selectTipo, tipo, isLoading, isSaving, enti, ente, selectEnte, tipiPiano}) => {
@@ -95,7 +95,7 @@ export default () => (
                 toast.error(errorQuery.message,  {autoClose: true})
             }
         return (
-            <Mutation mutation={CREA_PIANO} onCompleted={({createPiano: {nuovoPiano}} = {}) => window.location.href=`#/anagrafica/${nuovoPiano.codice}`} update={updateCache}>
+            <Mutation mutation={CREA_PIANO} onCompleted={({createPiano: {nuovoPiano}} = {}) => window.location.href=`#/crea_anagrafica/${nuovoPiano.codice}`} update={updateCache}>
                 {(creaPiano, { loading: isSaving, error: mutationError , ...rest}) => {
                 if (mutationError) {
                     toast.error(mutationError.message)

--- a/strt/serapide_client/src/pages/Piano.js
+++ b/strt/serapide_client/src/pages/Piano.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react'
+
+import { toast } from 'react-toastify'
+import { Route} from 'react-router-dom';
+import {Query} from "react-apollo"
+import Anagrafica from './Anagrafica'
+import {getEnteLabel, getPianoLabel} from "../utils"
+import {GET_PIANI} from "../queries"
+import Injector from '../components/Injector'
+import SideBar from '../components/SideBarMenu'
+const HOME = Anagrafica
+
+const getActive = (url = "", pathname = "") => {
+    return pathname.replace(url, "")
+}
+export default ({match: {url, path, params: {code} = {}} = {},location: {pathname} = {},  ...props}) => {
+    const activeLocation = getActive(url, pathname)
+    return (<Query query={GET_PIANI} variables={{codice: code}}>
+
+        {({loading, data: {piani: {edges = []} = []} = {}, error}) => {
+            if(loading){
+                return (
+                    <div className="serapide-content pt-5 pb-5 pX-md px-1 serapide-top-offset position-relative overflow-x-scroll">
+                        <div className="d-flex justify-content-center">
+                            <div className="spinner-grow " role="status">
+                                <span className="sr-only">Loading...</span>
+                        </div>
+                    </div>
+                    </div>)
+            } else if(edges.length === 0) {
+                toast.error(`Impossibile trovare il piano: ${code}`,  {autoClose: true})
+                return <div></div>
+            }
+            const {node: piano = {}} = edges[0] || {}
+            return(
+            <React.Fragment>
+                <Injector el="serapide-sidebar">
+                    <SideBar url={url} piano={piano} active={activeLocation}></SideBar>
+                </Injector>
+                <div className="serapide-content pt-5 pb-5 pX-md px-1 serapide-top-offset position-relative overflow-x-scroll">
+                    <div className="d-flex flex-column ">
+                        <h4 className="text-uppercase">{getEnteLabel(piano.ente)}</h4>  
+                        <h2 className="mb-0 text-capitalize">{`${getPianoLabel(piano.tipo)} ${code}`}</h2>  
+                        <h5 className="text-capitalize">{getPianoLabel.descrizione}</h5>  
+                        
+                        <Route  path={`${path}/anagrafica`} component={Anagrafica}/>
+                        <Route  path={`${path}`} component={HOME}/>
+                        
+                            
+                    </div>
+                   
+                </div>
+            </React.Fragment>
+            )}
+        }
+    </Query>)
+    }

--- a/strt/serapide_client/src/utils.js
+++ b/strt/serapide_client/src/utils.js
@@ -2,3 +2,4 @@
 
 export const getEnteLabel = ({name = "", code, type: {tipoente = ""} ={}} = {}) => `${tipoente} di ${name}`
 export const getEnteLabelID = ({name = "", code, type: {tipoente = ""} ={}} = {}) => `ID ${tipoente} ${code}`
+export const getPianoLabel = (tipo = "") => (tipo === "VARIANTE" ? tipo.toLowerCase() : `piano ${tipo.toLowerCase()}`)

--- a/strt/templates/base.html
+++ b/strt/templates/base.html
@@ -32,7 +32,7 @@ LICENSE file in the root directory of this source tree.
     <body>
 
         <!-- CONTAINER-FLUID -->
-        <div class="container-fluid p-0">
+        <div class="container-fluid p-0" >
 
             <!-- TOP-NAVBAR -->
             <nav class="navbar navbar-expand-md navbar-dark bg-dark sticky-top pl-0 py-0 top-navbar">
@@ -84,18 +84,24 @@ LICENSE file in the root directory of this source tree.
             {% block user_navbar %}
                 <!-- Here the user toolbar -->
             {% endblock user_navbar %}
-
+            
+            
             <!-- CONTENT -->
-            <div class="content bg-light">
-
+            <div class="content bg-light d-flex">
                 <!-- start content block -->
+                
+                <div id="serapide-sidebar" class="sidebar">
+                        
+                </div>
+                    
                 {% block content %}
 
                     <!-- put the content here -->
 
                 {% endblock content %}
+            
                 <!-- end content block -->
-
+                
             </div> <!-- end CONTENT -->
 
             <!-- FOOTER -->

--- a/strt/theme/scss/__base.scss
+++ b/strt/theme/scss/__base.scss
@@ -1,12 +1,21 @@
 .content {
     min-height: calc(100vh - 196px);
-    padding-left: $portal-header;
-    padding-right: $portal-header;
-    padding-bottom: $portal-header;
+    // padding-bottom: $portal-header;
+    padding-top: $portal-header;
+
 }
 /** colori notifiche**/
 .icon-34 {
     font-size: 34px;
+}
+.icon-16 {
+    font-size: 16px;
+}
+.icon-14 {
+    font-size: 14px;
+}
+.icon-12 {
+    font-size: 12px;
 }
 .first {
     order: -1;
@@ -58,6 +67,7 @@
     overflow: scroll;
 }
 .serapide {
+    width: 100%;
     .pointer{
         cursor: pointer;
     }
@@ -151,9 +161,8 @@ a {
 }
 
 @include media-breakpoint-down(md) {
-    .content {
-        padding-left: 1vw;
-        padding-right: 1vw;
+    .content{
+        padding-top: $portal-header - 4;
     }
     .big-text {
         font-size: 30px;

--- a/strt/theme/scss/__navbar.scss
+++ b/strt/theme/scss/__navbar.scss
@@ -73,6 +73,7 @@
             @include media-breakpoint-down($breakpoint) {
                 &.navbar{
                     height: auto;
+                    min-height:$portal-header;
                 }
                 .link-icon {
                     flex-flow: row;

--- a/strt/theme/scss/__sidebar.scss
+++ b/strt/theme/scss/__sidebar.scss
@@ -1,0 +1,81 @@
+.sidebar {
+    background-color: rgb(81, 80, 80) !important;
+    color:white;
+    
+
+    .sidebar-header{
+        min-width: 250px;
+        padding: 8px;
+        .close{
+            color: $warning;
+            font-size: 1rem;
+            text-shadow: none;
+            opacity: 1;
+            display: inline-block;
+
+        }
+        
+        margin-bottom: 10px;
+        .title {
+            font-size: 15px;
+        }
+        .piano-title {
+            font-size: 20px;
+        }
+    }
+    .sidebar-header.collapsed{
+        margin-bottom: 0px;
+        padding-left: 6px;
+        padding-right: 6px;
+        min-width: 0px;
+    }
+
+    .list-group {
+        .list-group-item {
+            display: flex;
+            align-items: center;
+            background-color: inherit;
+            border: none;
+            border-radius: 0;
+            border-top: 1px solid rgb(215, 216, 210);
+            border-bottom: 1px solid rgb(215, 216, 210);
+            min-height: 70px;
+            cursor: pointer;
+            .icons{
+                margin-right: 0.8rem;
+            }
+            .title {
+                font-size: 15px;
+            }
+            .sub-title {
+                font-size: 12px;
+            }
+            .badge {
+                position: absolute;
+                right: 10px;
+            }
+        }
+        .list-group-item.locked {
+            cursor: not-allowed;
+        }
+        .list-group-item.collapsed {
+            padding: 0px;
+            padding-left: 4px;
+            padding-right: 4px;
+            min-height: 60px;
+            .icons{
+                padding-left: 2px;
+                padding-right: 2px;
+                margin-right: 0px;
+            }
+        }
+        .list-group-item.active{
+            background-color: rgb(60, 59, 59);
+            border-left: 4px solid $warning;
+            color: $warning;
+        }
+        .list-group-item.active.collapsed{
+            padding-left: 0px;
+        }
+    }
+}

--- a/strt/theme/scss/__statoProgress.scss
+++ b/strt/theme/scss/__statoProgress.scss
@@ -18,6 +18,9 @@ $space-between: ($stato-progress-width - 40) /4;
        transform: translateX(($stato-progress-width * -0.5) + 4);
        color: $warning;    
       }
+    i.draft{
+      color: $gray-400;
+    }
     width: $stato-progress-width;
     flex-direction: column;
     display: inline-flex;

--- a/strt/theme/scss/serapide.scss
+++ b/strt/theme/scss/serapide.scss
@@ -12,6 +12,7 @@
     @import "./_usermenu";
     @import "./_menumessaggi";
     @import "./_fileChooser";
+    
 }
-
+@import "./_sidebar";
 @import "./_base";


### PR DESCRIPTION
Aggiunta la pagina per il piano con tutti i sottomenu, per ora solo di primo livello, contenuti nella sidebar.
La pagina piano è un contenitore che renderizza con un router innestato il componente necessario.
Al momento attuale solo la pagina anagrafica è implementata.
Manca anche la logica da utilizzare per bloccare le varie fasi